### PR TITLE
Margin around the stackview

### DIFF
--- a/Example/ScrollableStackView/VerticalLayoutViewController.swift
+++ b/Example/ScrollableStackView/VerticalLayoutViewController.swift
@@ -21,6 +21,7 @@ class VerticalLayoutViewController: UIViewController {
         scrollable.stackView.distribution = .fillProportionally
         scrollable.stackView.alignment = .center
         scrollable.stackView.axis = .vertical
+		scrollable.scrollView.layoutMargins = UIEdgeInsets(top: 15, left: 15, bottom: 15, right: 15)
         view.addSubview(scrollable)
         
         for _ in 1 ..< 23 {

--- a/Example/ScrollableStackView/VerticalLayoutViewController.swift
+++ b/Example/ScrollableStackView/VerticalLayoutViewController.swift
@@ -21,7 +21,7 @@ class VerticalLayoutViewController: UIViewController {
         scrollable.stackView.distribution = .fillProportionally
         scrollable.stackView.alignment = .center
         scrollable.stackView.axis = .vertical
-		scrollable.scrollView.layoutMargins = UIEdgeInsets(top: 15, left: 15, bottom: 15, right: 15)
+        scrollable.scrollView.layoutMargins = UIEdgeInsets(top: 15, left: 15, bottom: 15, right: 15)
         view.addSubview(scrollable)
         
         for _ in 1 ..< 23 {

--- a/ScrollableStackView/Classes/ScrollableStackView.swift
+++ b/ScrollableStackView/Classes/ScrollableStackView.swift
@@ -27,6 +27,7 @@ import UIKit
         // ScrollView
         scrollView = UIScrollView(frame: self.frame)
         scrollView.translatesAutoresizingMaskIntoConstraints = false
+		scrollView.layoutMargins = .zero
         self.addSubview(scrollView)
         
         // StackView
@@ -120,9 +121,12 @@ import UIKit
             addConstraint(NSLayoutConstraint(item: scrollView, attribute: .bottom, relatedBy: .equal, toItem: self, attribute: .bottom, multiplier: 1.0, constant: 0))
             addConstraint(NSLayoutConstraint(item: scrollView, attribute: .top, relatedBy: .equal, toItem: self, attribute: .top, multiplier: 1.0, constant: 0))
             
-            addConstraints(NSLayoutConstraint.constraints(withVisualFormat: "H:[stackView(==scrollView)]", options: .alignAllCenterX, metrics: nil, views: ["stackView": stackView, "scrollView": scrollView]))
-            addConstraints(NSLayoutConstraint.constraints(withVisualFormat: "V:|[stackView]|", options: .alignAllCenterX, metrics: nil, views: ["stackView": stackView]))
-            
+			addConstraints(NSLayoutConstraint.constraints(withVisualFormat: "V:|-[stackView]-|", options: [], metrics: nil, views: ["stackView": stackView]))
+			
+			let margins = scrollView.layoutMarginsGuide
+			stackView.leadingAnchor.constraint(equalTo: margins.leadingAnchor).isActive = true
+			stackView.trailingAnchor.constraint(equalTo: margins.trailingAnchor).isActive = true
+			
             didSetupConstraints = true
         }
     }

--- a/ScrollableStackView/Classes/ScrollableStackView.swift
+++ b/ScrollableStackView/Classes/ScrollableStackView.swift
@@ -27,7 +27,7 @@ import UIKit
         // ScrollView
         scrollView = UIScrollView(frame: self.frame)
         scrollView.translatesAutoresizingMaskIntoConstraints = false
-		scrollView.layoutMargins = .zero
+        scrollView.layoutMargins = .zero
         self.addSubview(scrollView)
         
         // StackView
@@ -121,12 +121,12 @@ import UIKit
             addConstraint(NSLayoutConstraint(item: scrollView, attribute: .bottom, relatedBy: .equal, toItem: self, attribute: .bottom, multiplier: 1.0, constant: 0))
             addConstraint(NSLayoutConstraint(item: scrollView, attribute: .top, relatedBy: .equal, toItem: self, attribute: .top, multiplier: 1.0, constant: 0))
             
-			addConstraints(NSLayoutConstraint.constraints(withVisualFormat: "V:|-[stackView]-|", options: [], metrics: nil, views: ["stackView": stackView]))
-			
-			let margins = scrollView.layoutMarginsGuide
-			stackView.leadingAnchor.constraint(equalTo: margins.leadingAnchor).isActive = true
-			stackView.trailingAnchor.constraint(equalTo: margins.trailingAnchor).isActive = true
-			
+            addConstraints(NSLayoutConstraint.constraints(withVisualFormat: "V:|-[stackView]-|", options: [], metrics: nil, views: ["stackView": stackView]))
+            
+            let margins = scrollView.layoutMarginsGuide
+            stackView.leadingAnchor.constraint(equalTo: margins.leadingAnchor).isActive = true
+            stackView.trailingAnchor.constraint(equalTo: margins.trailingAnchor).isActive = true
+            
             didSetupConstraints = true
         }
     }

--- a/ScrollableStackView/Classes/ScrollableStackView.swift
+++ b/ScrollableStackView/Classes/ScrollableStackView.swift
@@ -114,14 +114,14 @@ import UIKit
         super.updateConstraints()
         
         if (!didSetupConstraints) {
-            self.addConstraint(NSLayoutConstraint(item: scrollView, attribute: .left, relatedBy: .equal, toItem: self, attribute: .left, multiplier: 1.0, constant: 0))
-            self.addConstraint(NSLayoutConstraint(item: scrollView, attribute: .right, relatedBy: .equal, toItem: self, attribute: .right, multiplier: 1.0, constant: 0))
+            addConstraint(NSLayoutConstraint(item: scrollView, attribute: .left, relatedBy: .equal, toItem: self, attribute: .left, multiplier: 1.0, constant: 0))
+            addConstraint(NSLayoutConstraint(item: scrollView, attribute: .right, relatedBy: .equal, toItem: self, attribute: .right, multiplier: 1.0, constant: 0))
             
-            self.addConstraint(NSLayoutConstraint(item: scrollView, attribute: .bottom, relatedBy: .equal, toItem: self, attribute: .bottom, multiplier: 1.0, constant: 0))
-            self.addConstraint(NSLayoutConstraint(item: scrollView, attribute: .top, relatedBy: .equal, toItem: self, attribute: .top, multiplier: 1.0, constant: 0))
+            addConstraint(NSLayoutConstraint(item: scrollView, attribute: .bottom, relatedBy: .equal, toItem: self, attribute: .bottom, multiplier: 1.0, constant: 0))
+            addConstraint(NSLayoutConstraint(item: scrollView, attribute: .top, relatedBy: .equal, toItem: self, attribute: .top, multiplier: 1.0, constant: 0))
             
-            self.addConstraints(NSLayoutConstraint.constraints(withVisualFormat: "H:[stackView(==scrollView)]", options: .alignAllCenterX, metrics: nil, views: ["stackView": stackView, "scrollView": scrollView]))
-            self.addConstraints(NSLayoutConstraint.constraints(withVisualFormat: "V:|[stackView]|", options: .alignAllCenterX, metrics: nil, views: ["stackView": stackView]))
+            addConstraints(NSLayoutConstraint.constraints(withVisualFormat: "H:[stackView(==scrollView)]", options: .alignAllCenterX, metrics: nil, views: ["stackView": stackView, "scrollView": scrollView]))
+            addConstraints(NSLayoutConstraint.constraints(withVisualFormat: "V:|[stackView]|", options: .alignAllCenterX, metrics: nil, views: ["stackView": stackView]))
             
             didSetupConstraints = true
         }


### PR DESCRIPTION
Hi Gürhan,

I have modified the auto layout code, so that this is now possible. It should not break anything for other users.

The Example project now has a 15px margin around the stackview.

The horizontal constraint was changed from a textual formatting to instead use `leadingAnchor` and `trailingAnchor`.

The vertical constraint was a minor change.

